### PR TITLE
gh-pages 의존성 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
         cp dist/index.html dist/404.html
         cp -r public dist/
     - name: Deploy  
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/main'
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        BASE_BRANCH: master
+        BASE_BRANCH: main
         BRANCH: gh-pages
         FOLDER: dist

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "test:e2e": "codeceptjs run --steps",
     "test": "npm run coverage && start-server-and-test start http://localhost:8080 test:e2e",
     "lint": "eslint --ext js,jsx .",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist",
     "build": "webpack --mode production --config webpack.config.js",
     "build:dev": "webpack --mode development --config webpack.config.js"
   },
@@ -39,7 +37,6 @@
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^2.5.1",
     "file-loader": "^6.2.0",
-    "gh-pages": "^3.1.0",
     "given2": "^2.1.7",
     "html-webpack-plugin": "^4.5.0",
     "jest": "^26.0.1",


### PR DESCRIPTION
gh-pages 패키지 대신 github workflows를 사용하기 위해 기존 코드를 제거함